### PR TITLE
Support multiple product IDs

### DIFF
--- a/server.py
+++ b/server.py
@@ -20,19 +20,20 @@ from http.server import HTTPServer, BaseHTTPRequestHandler
 def catch():
     output = ""
     VENDOR_ID = 0x0764
-    PRODUCT_ID = 0x0601
-    device_list = hid.enumerate(VENDOR_ID, PRODUCT_ID)
-    for device_item in device_list:
-        device = hid.Device(path=device_item['path'])
-        ups = CyberPower(device)
-        res = ups.dict_status()
-        firmware = res["firmware"]
-        for key,value in res.items():
-            if value in [True,False]:
-                value = int(value == True)
-            if isinstance(value, int):
-                output += "ups_{}{{firmware=\"{}\"}} {}\n".format(key, firmware, value)
-        device.close()
+    product_ids = [0x0501, 0x0601]
+    for product_id in product_ids:
+        device_list = hid.enumerate(VENDOR_ID, product_id)
+        for device_item in device_list:
+            device = hid.Device(path=device_item['path'])
+            ups = CyberPower(device)
+            res = ups.dict_status()
+            firmware = res["firmware"]
+            for key,value in res.items():
+                if value in [True,False]:
+                    value = int(value == True)
+                if isinstance(value, int):
+                    output += "ups_{}{{firmware=\"{}\"}} {}\n".format(key, firmware, value)
+            device.close()
     return output.encode("ascii")
 
 class CatchHandler(BaseHTTPRequestHandler):

--- a/usb.py
+++ b/usb.py
@@ -95,18 +95,19 @@ class CyberPower:
 
 def main():
     VENDOR_ID = 0x0764
-    PRODUCT_ID = 0x0601
-    device_list = hid.enumerate(VENDOR_ID, PRODUCT_ID)
-    for device_item in device_list:
-        device = hid.Device(path=device_item['path'])
+    product_ids = [0x0501, 0x0601]
+    for product_id in product_ids:
+        device_list = hid.enumerate(VENDOR_ID, product_id)
+        for device_item in device_list:
+            device = hid.Device(path=device_item['path'])
 
-        ups = CyberPower(device)
-        # This crashes the hid library because some of these devices have no serial...
-        #print("Serial Number: {}".format(device.))
-        print(ups.dict_status())
-        # If you just need the remaining time and battery charge
-        # print(ups.quick_status())
-        device.close()
+            ups = CyberPower(device)
+            # This crashes the hid library because some of these devices have no serial...
+            #print("Serial Number: {}".format(device.))
+            print(ups.dict_status())
+            # If you just need the remaining time and battery charge
+            # print(ups.quick_status())
+            device.close()
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
I have two UPS devices connected to the same host, and coincidentally, they have different product IDs (shown below).

This PR allows iterating over multiple product IDs to fetch all the stats from all the devices.

```
$ lsusb
<snip>
Bus 003 Device 004: ID 0764:0501 Cyber Power System, Inc. CP1500 AVR UPS
Bus 003 Device 003: ID 0764:0601 Cyber Power System, Inc. PR1500LCDRT2U UPS
```